### PR TITLE
fix: add check for key existence in state dictionary

### DIFF
--- a/graph/nodes/web_search.py
+++ b/graph/nodes/web_search.py
@@ -11,7 +11,7 @@ web_search_tool = TavilySearchResults(k=3)
 def web_search(state: GraphState) -> Dict[str, Any]:
     print("---WEB SEARCH---")
     question = state["question"]
-    documents = state["documents"]
+    documents = state.get("documents")
 
     docs = web_search_tool.invoke({"query": question})
     web_results = "\n".join([d["content"] for d in docs])


### PR DESCRIPTION
Changed access to "documents" in the state dictionary to use state.get() in WEBSEARCH 

When adding the router as an entry point, the document status is not passed, so the error below is displayed when trying to access the variable

File ".../self_rag/graph/nodes/web_search.py", line 19, in web_search
    documents = state['documents']
                ~~~~~^^^^^^^^^^^^^
KeyError: 'documents'